### PR TITLE
Modify signal for ctrl+D

### DIFF
--- a/Libft/libft.h
+++ b/Libft/libft.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   libft.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gaekim <gaekim@42.fr>                      +#+  +:+       +#+        */
+/*   By: daelee <daelee@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/04/17 00:11:45 by gaekim            #+#    #+#             */
-/*   Updated: 2021/01/14 20:38:43 by gaekim           ###   ########.fr       */
+/*   Updated: 2021/01/24 21:35:20 by daelee           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,12 +14,29 @@
 # define LIBFT_H
 # include <stdlib.h>
 # include <unistd.h>
+# include <limits.h>
+
+# ifndef BUFFER_SIZE
+#  define BUFFER_SIZE 1
+# endif
+
+# ifndef FD_NUMBER
+#  define FD_NUMBER 256
+# endif
 
 typedef struct	s_list
 {
 	void			*content;
 	struct s_list	*next;
 }				t_list;
+
+typedef struct	s_gnl_material
+{
+	int			value_to_print_exist;
+	char		buffer[BUFFER_SIZE];
+	size_t		start_idx;
+	size_t		last_idx;
+}				t_gnl_material;
 
 int				ft_isalnum(int c);
 int				ft_isalpha(int c);

--- a/builtins/ft_echo.c
+++ b/builtins/ft_echo.c
@@ -6,7 +6,7 @@
 /*   By: daelee <daelee@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/08 10:59:48 by daelee            #+#    #+#             */
-/*   Updated: 2021/01/14 14:08:36 by daelee           ###   ########.fr       */
+/*   Updated: 2021/01/24 21:46:18 by daelee           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,10 +29,10 @@ void		ft_echo(char **cmdline)
 			option++;
 			i++;
 		}
-		ft_putstr_fd(cmdline[i], 1);
+		ft_putstr_fd(cmdline[i], STDIN_FILENO);
 		if (cmdline[i + 1] != NULL)
-			ft_putstr_fd(" ", 1);
+			ft_putstr_fd(" ", STDIN_FILENO);
 	}
 	if (option == 0)
-		ft_putstr_fd("\n", 1);
+		ft_putstr_fd("\n", STDIN_FILENO);
 }

--- a/builtins/ft_exit.c
+++ b/builtins/ft_exit.c
@@ -6,7 +6,7 @@
 /*   By: daelee <daelee@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/11 09:52:14 by daelee            #+#    #+#             */
-/*   Updated: 2021/01/14 14:08:36 by daelee           ###   ########.fr       */
+/*   Updated: 2021/01/24 21:46:29 by daelee           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,10 +29,10 @@ void		ft_exit(char **cmdline)
 		exit(ft_atoi(cmdline[1]));
 	}
 	else if (argc > 2 && ft_isdigit_str(cmdline[1]))
-		ft_putendl_fd("bash: exit: too many arguments", 1);
+		ft_putendl_fd("bash: exit: too many arguments", STDIN_FILENO);
 	else
 	{
-		ft_putstr_fd("bash: exit: numeric argument required", 1);
+		ft_putstr_fd("bash: exit: numeric argument required", STDIN_FILENO);
 		exit(2);
 	}
 }

--- a/builtins/ft_export.c
+++ b/builtins/ft_export.c
@@ -6,7 +6,7 @@
 /*   By: daelee <daelee@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/11 11:44:44 by daelee            #+#    #+#             */
-/*   Updated: 2021/01/14 14:08:36 by daelee           ###   ########.fr       */
+/*   Updated: 2021/01/24 21:46:35 by daelee           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@ int	        print_export(char **envs)
 	i = -1;
 	while (envs[++i])
 	{
-		ft_putstr_fd(envs[i], 1);
+		ft_putstr_fd(envs[i], STDIN_FILENO);
 		write(1, "\n", 1);
 	}
 	return (SUCCESS);

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: daelee <daelee@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/07 09:46:05 by daelee            #+#    #+#             */
-/*   Updated: 2021/01/24 10:00:14 by daelee           ###   ########.fr       */
+/*   Updated: 2021/01/24 21:47:01 by daelee           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ void	show_daegae(void)
 	fd = open("utils/ascii_art", O_RDONLY);
 	while (get_next_line(fd, &line))
 	{
-		ft_putstr_fd("\033[36m", 1);
+		ft_putstr_fd("\033[36m", STDIN_FILENO);
 		ft_putendl_fd(line, STDOUT_FILENO);
 		free(line);
 	}
@@ -37,9 +37,9 @@ void	show_prompt(void)
 {
 	static char	*curpath;
 
-	ft_putstr_fd(" \033[1;96m", 1);
-	ft_putstr_fd(getcwd(curpath, MAXSIZE), 1);
-	ft_putstr_fd("\033[1;93m $\033[0m ", 1);
+	ft_putstr_fd(" \033[1;96m", STDIN_FILENO);
+	ft_putstr_fd(getcwd(curpath, MAXSIZE), STDIN_FILENO);
+	ft_putstr_fd("\033[1;93m $\033[0m ", STDIN_FILENO);
 }
 
 int		main(int argc, char **argv, char **envp)
@@ -58,7 +58,8 @@ int		main(int argc, char **argv, char **envp)
 		if (!get_next_line(0, &input) && !ft_strlen(input))
 		{
 			free(input);
-			ft_putendl_fd("exit", 1);
+			ft_putstr_fd("  \b\b", STDIN_FILENO);
+			ft_putstr_fd("exit\n", STDIN_FILENO);
 			exit(EXIT_SUCCESS);
 		}
 		// else if (parsing(input))

--- a/minishell.h
+++ b/minishell.h
@@ -12,10 +12,19 @@
 # include "Libft/libft.h"
 
 # define MAXSIZE 1024
+
 # define FALSE 0
 # define TRUE 1 
+
 # define ERROR 0
 # define SUCCESS 1
+
+# define ERROR_P NULL
+# define BASH_SUCCESS 0
+# define BASH_ERR_NOL 1
+# define BASH_ERR_SYN 2 // 잘못 사용된 builtin 명령, syntax error
+# define BASH_ERR_EXE 126 // 명령 실행 불가, 명령은 존재하지만 excutable 이 아니거나 퍼미션 문제
+# define BASH_ERR_NOF 127 // not found, 파일이 존재하지 않음
 
 typedef struct	s_cmd
 {

--- a/utils/utils_main.c
+++ b/utils/utils_main.c
@@ -6,7 +6,7 @@
 /*   By: daelee <daelee@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/12 23:29:46 by daelee            #+#    #+#             */
-/*   Updated: 2021/01/24 10:01:14 by daelee           ###   ########.fr       */
+/*   Updated: 2021/01/24 21:41:45 by daelee           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,6 @@ void    set_signal(void)
 {
     signal(SIGINT, handle_signal);
 	signal(SIGQUIT, handle_signal);
-	signal(SIGTERM, handle_signal);
 }
 
 void	handle_child_signal(int signo)


### PR DESCRIPTION
- SIGTERM 시 ^D 문자가 터미널에 입력되는 문제 해결
    → gnl 문제였음. 버퍼사이즈 1씩 읽어주니 잘 지워짐.
- cat | 같은 자식 프로세스 생성했을 때 시그널 테스트 해봐야해서 signal_child_daelee 브랜치 새로 생성
- 기존 signal_daelee 브랜치는 삭제